### PR TITLE
Compilation on OS X (Darwin)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,14 @@ INSTALL = install
 INSTALL_PROGRAM = $(INSTALL) -m 755
 INSTALL_DATA    = $(INSTALL) -m 644
 
+ifneq ($(OS),Windows_NT)
+	UNAME_S := $(shell uname -s)
+
+	ifeq ($(UNAME_S),Darwin)
+		CC = clang
+	endif
+endif
+
 all: $(TARGET)
 build-shared: $(SHARED_TRG)
 lib-shared: $(SHAREDLIB)

--- a/librhash/Makefile
+++ b/librhash/Makefile
@@ -28,6 +28,9 @@ LIBDIR  = $(PREFIX)/lib
 LIBRARY = librhash.a
 SONAME  = librhash.so.0
 SOLINK  = librhash.so
+SONAME_DARWIN = librhash.0.dylib
+SOLINK_DARWIN = librhash.dylib
+LIB_SHARED_TARGET = $(SONAME)
 TEST_TARGET = test_hashes
 TEST_SHARED = test_shared
 # Set variables according to GNU coding standard
@@ -35,9 +38,18 @@ INSTALL = install
 INSTALL_DATA    = $(INSTALL) -m 644
 INSTALL_SHARED  = $(INSTALL) -m 644
 
+ifneq ($(OS),Windows_NT)
+	UNAME_S := $(shell uname -s)
+
+	ifeq ($(UNAME_S),Darwin)
+		CC = clang
+		LIB_SHARED_TARGET = $(SONAME_DARWIN)
+	endif
+endif
+
 all: $(LIBRARY)
 lib-static: $(LIBRARY)
-lib-shared: $(SONAME)
+lib-shared: $(LIB_SHARED_TARGET)
 libs-all: lib-static lib-shared
 dist-clean: clean
 
@@ -181,6 +193,10 @@ $(SONAME): $(SOURCES)
 	ln -s $(SONAME) $(SOLINK)
 # use 'nm -Cg --defined-only $@' to view exported symbols
 
+$(SONAME_DARWIN): $(SOURCES)
+	$(CC) -fpic $(ALLCFLAGS) -dynamiclib $(SOURCES) $(LIBLDFLAGS) -Wl,-install_name,$(PREFIX)/lib/$@ -o $@
+	ln -s $(SONAME_DARWIN) $(SOLINK_DARWIN)
+
 $(LIBRARY): $(OBJECTS)
 	$(AR) cqs $@ $(OBJECTS)
 #	$(AR) cr $(LIBRARY) $(OBJECTS) && runlib $(LIBRARY)
@@ -200,4 +216,4 @@ test: test-static
 #	if [ -f $(DLLNAME) ]; then make test-dll; fi
 
 clean:
-	rm -f *.o $(LIBRARY) $(TEST_TARGET) $(TEST_SHARED) $(SONAME) $(SOLINK) exports.sym $(DLLNAME) librhash.def
+	rm -f *.o $(LIBRARY) $(TEST_TARGET) $(TEST_SHARED) $(SONAME) $(SOLINK) $(SONAME_DARWIN) $(SOLINK_DARWIN) exports.sym $(DLLNAME) librhash.def


### PR DESCRIPTION
I already opened an issue on [SourceForge](http://sourceforge.net/p/rhash/bugs/45/) but didn't get a response, so I assume the bugtracker there isn't used anymore.

I made some changes to the Makefile to support compilation on Mac OS X.
Since I don't know much about Makefiles please double check these changes, compilation does work on my MacBook though.

It would be great if this, or an adapted version, could be integrated into upstream so I can update the Homebrew Formula on Mac OS X to build the shared and static libraries too.
