### PR TITLE
Avoid nonportable use of grep.

### DIFF
--- a/tests/test_rhash.sh
+++ b/tests/test_rhash.sh
@@ -143,17 +143,17 @@ TEST_RESULT=$( $rhash --simple -a test1K.data | $rhash -vc - 2>/dev/null | grep 
 match "$TEST_RESULT" "^test1K.data *OK"
 
 new_test "test checking magnet link:  "
-TEST_RESULT=$( $rhash --magnet -a test1K.data | $rhash -vc - 2>&1 | grep -i '\(warn\|test1K.data\)' )
+TEST_RESULT=$( $rhash --magnet -a test1K.data | $rhash -vc - 2>&1 | grep -i -e warn -e test1K.data )
 TEST_EXPECTED="^test1K.data *OK"
 match "$TEST_RESULT" "$TEST_EXPECTED"
 
 new_test "test bsd format checking:   "
-TEST_RESULT=$( $rhash --bsd -a test1K.data | $rhash -vc - 2>&1 | grep -i '\(warn\|err\)' )
+TEST_RESULT=$( $rhash --bsd -a test1K.data | $rhash -vc - 2>&1 | grep -i -e warn -e err )
 check "$TEST_RESULT" ""
 
 new_test "test checking w/o filename: "
 $rhash -p '%c\n%m\n%e\n%h\n%g\n%t\n%a\n' test1K.data > test1K.data.hash
-TEST_RESULT=$( $rhash -vc test1K.data.hash 2>&1 | grep -i '\(warn\|err\)' )
+TEST_RESULT=$( $rhash -vc test1K.data.hash 2>&1 | grep -i -e warn -e err )
 TEST_EXPECTED=""
 check "$TEST_RESULT" "$TEST_EXPECTED"
 


### PR DESCRIPTION
OpenBSD's grep doesn't support `'\(foo\|bar\)'`, causing the magnet test to fail.

This commit uses POSIX's grep -e instead to match multiple patterns.
