### PR TITLE
Add a --printf directive that outputs a URL-encoded version of the full path

### DIFF
--- a/dist/rhash.1
+++ b/dist/rhash.1
@@ -226,6 +226,8 @@ File's path.
 File's name.
 .IP %u
 URL\(hyencoded filename.
+.IP %P
+URL\(hyencoded full path of the file.
 .IP %s
 File's size in bytes.
 .IP %{mtime}

--- a/tests/test_rhash.sh
+++ b/tests/test_rhash.sh
@@ -208,6 +208,15 @@ TEST_RESULT=$( $rhash --btih --torrent --bt-private --bt-piece-length=512 --bt-a
 check "$TEST_RESULT" "29f7e9ef0f41954225990c513cac954058721dd2  test1K.data"
 rm test1K.data.torrent
 
+new_test "test url encoded path:      "
+mkdir -p 'test_directory_with_"quotes"'
+touch 'test_directory_with_"quotes"/test_file_with_"quotes".out'
+TEST_RESULT=$( $rhash -p '%M,%p,%P\n' 'test_directory_with_"quotes"/test_file_with_"quotes".out' )
+TEST_EXPECTED='D41D8CD98F00B204E9800998ECF8427E,test_directory_with_"quotes"/test_file_with_"quotes".out,test_directory_with_%22quotes%22%2Ftest_file_with_%22quotes%22.out'
+check "$TEST_RESULT" "$TEST_EXPECTED"
+rm 'test_directory_with_"quotes"/test_file_with_"quotes".out'
+rmdir -p 'test_directory_with_"quotes"'
+
 new_test "test exit code:             "
 rm -f none-existent.file
 test -f none-existent.file && print_failed .


### PR DESCRIPTION
This change adds a new "--printf" directive "%P" that outputs a URL-encoded version of the full path.  It is useful when trying to use the "printf" feature to output ~~CSV~~ tab-delimited files (and other machine-readable files like json) on directories that have special characters.   It uses the same code to get the full path as the existing "%p" directive and the same url-encoding library as the existing "%u" directive.

The specific use-case I has, was to want to use:

`rhash -r -p "%M\t%s\t%P\n" /mnt/enc3`

to create a clean tab delimited file which could be loaded by other tools for further analysis.

Without this option, a filesystem path may contain almost arbitrary characters, making it challenging (perhaps impossible) to create a clean tab-delimited file or a file containing a clean json array on each line.

This patch includes a test case, and updates to the docs.
