### PR TITLE
md5: Avoid signed left-shift overflow

### DIFF
--- a/librhash/md5.c
+++ b/librhash/md5.c
@@ -213,8 +213,8 @@ void rhash_md5_final(md5_ctx *ctx, unsigned char* result)
 	/* pad message and run for last block */
 
 	/* append the byte 0x80 to the message */
-	ctx->message[index]   &= ~(0xFFFFFFFF << shift);
-	ctx->message[index++] ^= 0x80 << shift;
+	ctx->message[index]   &= ~(0xFFFFFFFFu << shift);
+	ctx->message[index++] ^= 0x80u << shift;
 
 	/* if no room left in the message to store 64-bit message length */
 	if (index > 14) {


### PR DESCRIPTION
Fix `rhash_md5_final` to use unsigned integers for left shifting to avoid the possibility of undefined overflow behavior.

This was exposed by UBSan:

    .../librhash/md5.c:217:32: runtime error:
      left shift of 128 by 24 places cannot be represented in type 'int'