### PR TITLE
librhash/byte_order.h: Consult also compiler's predefined macros.

### DIFF
--- a/librhash/byte_order.h
+++ b/librhash/byte_order.h
@@ -38,6 +38,8 @@ extern "C" {
 /* detect CPU endianness */
 #if (defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN) && \
 		__BYTE_ORDER == __LITTLE_ENDIAN) || \
+	(defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
+		__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) || \
 	defined(CPU_IA32) || defined(CPU_X64) || \
 	defined(__ia64) || defined(__ia64__) || defined(__alpha__) || defined(_M_ALPHA) || \
 	defined(vax) || defined(MIPSEL) || defined(_ARM_) || defined(__arm__)
@@ -46,6 +48,8 @@ extern "C" {
 # define IS_LITTLE_ENDIAN 1
 #elif (defined(__BYTE_ORDER) && defined(__BIG_ENDIAN) && \
 		__BYTE_ORDER == __BIG_ENDIAN) || \
+	(defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
+		__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) || \
 	defined(__sparc) || defined(__sparc__) || defined(sparc) || \
 	defined(_ARCH_PPC) || defined(_ARCH_PPC64) || defined(_POWER) || \
 	defined(__POWERPC__) || defined(POWERPC) || defined(__powerpc) || \


### PR DESCRIPTION
Recently I created patch for [Alpine Linux](https://alpinelinux.org/)'s [aports](http://git.alpinelinux.org/cgit/aports/) to include rhash in its repository, because I find this tool very useful. Unfortunately building on aarch64 (64-bit ARM architecture) failed, but I don't have access to such hardware, so I couldn't check it earlier.

Investigating build logs made me realize that byte_order.h has too much hardcoded stuff, yet it fails work on "unknown" platforms with non-glibc libc implementations. I think that ultimately this header should be rewritten, but w/o having access to all the platforms to retest it there, I didn't go that way. Instead I simply added another way to check endianness that depends on compiler's provided macros (at least gcc and clang provide them), that are usually used by `<endian.h>` anyway.

After successfully building and running `tests/test_rhash.sh` on aarch64 (kudos to @clandmeter who has access to such hardware and was kind enough to do builds and run test), the patch has been added to Alpine Linux repository in [testing/rhash](http://git.alpinelinux.org/cgit/aports/tree/testing/rhash/) and therefore rhash is [available](http://pkgs.alpinelinux.org/packages?name=rhash) in edge's testing repository for now.

Now I would like to upstream the improvement.

### Commit message

byte_order.h includes `<endian.h>` only if glibc is used (i.e. `__GLIBC__` is defined), but there are other libc implementation that also provide endian.h, like musl libc for instance.  Generally it's much better and
cleaner to check feature test macros than check for particular implementation (and that is also why musl libc doesn't define `__MUSL__`). Unfortunately I am not aware of feature test macro guaranteeing endian.h availability.

The simple solution is to add checking for compiler's pre-defined macros (`__BYTE_ORDER__`, `__ORDER_LITTLE_ENDIAN__`, `__ORDER_LITTLE_ENDIAN__`) after checking macros coming from system headers, i.e. `<endian.h>` in this case (`__BYTE_ORDER`, `__BIG_ENDIAN`, `__LITTLE_ENDIAN`).

That way we can better support new architectures w/o hardcoding their endianness, which is especially useful if they support both.