### PR TITLE
sff GETTEXT_LDFLAGS flags and LIBDL_LDFLAGS to .pc file's Libs.privat…

### DIFF
--- a/configure
+++ b/configure
@@ -892,7 +892,7 @@ Description: LibRHash shared library
 Version: ${RHASH_VERSION}
 Cflags: -I\${includedir}
 Libs: -L\${libdir} -lrhash
-Libs.private: ${OPENSSL_LDFLAGS}
+Libs.private: ${OPENSSL_LDFLAGS} ${GETTEXT_LDFLAGS} ${LIBDL_LDFLAGS}
 
 EOF
 fi


### PR DESCRIPTION
…e .  This is necessary when using those libraries, otherwise compiling may break.