### PR TITLE
Fix broken link to list of supported hash functions

### DIFF
--- a/README
+++ b/README
@@ -40,7 +40,7 @@ Features:
 
  * RHash hash functions descriptions http://rhash.anz.ru/hashes.php
  * The table of the hash functions supported by RHash
-   http://sf.net/apps/mediawiki/rhash/index.php?title=Hash_sums
+   https://sf.net/p/rhash/wiki/HashFunctions/
  * ECRYPT: The Hash Function Zoo
    http://ehash.iaik.tugraz.at/wiki/The_Hash_Function_Zoo
 


### PR DESCRIPTION
Replaced broken link to list of supported hash function by rhash.
Very trivial fix, feel free to update yourself and close this PR without merging.