### PR TITLE
configure: Don't quote $CC when calling it

### DIFF
--- a/configure
+++ b/configure
@@ -480,7 +480,7 @@ if test "$(basename $CC)" = "icc" || test "$(basename $CC)" = "ecc"; then
 else
   CC_TMP="$CC"
   for CC in "$CC_TMP" gcc cc ; do
-    if "$CC" -v >/dev/null 2>&1; then
+    if $CC -v >/dev/null 2>&1; then
       cc_name_tmp=$($CC -v 2>&1 | tail -n 1 | cut -d ' ' -f 1)
       if test "$cc_name_tmp" = "gcc"; then
         cc_name=$cc_name_tmp


### PR DESCRIPTION
It might have additional arguments.

Can't say I'm too impressed with the new "configure" script, sorry. Seems more of a sideways step. Autotools, CMake, and Meson are all saner options than this.