### PR TITLE
configure: Add target OS clause for Darwin

### DIFF
--- a/configure
+++ b/configure
@@ -410,6 +410,7 @@ else
       amigaos) TARGET_OS=AmigaOS ;;
       mingw32*) TARGET_OS=MINGW32 ;;
       wine) TARGET_OS=Wine ;;
+      darwin*) TARGET_OS=Darwin ;;
     esac
   }
   TARGET_OS="UNKNOWN"


### PR DESCRIPTION
These triplets can also have a version number suffix, for example, `x86_64-apple-darwin16`.