### PR TITLE
Honour XDG compliant config file location

### DIFF
--- a/dist/rhash.1
+++ b/dist/rhash.1
@@ -269,7 +269,7 @@ base64 or raw (binary) format respectively, e.g. %b{md4}, %BH or %xT.
 
 .SH CONFIG FILE
 RHash looks for a config file
-at $HOME/.rhashrc and /etc/rhashrc.
+at $XDG_CONFIG_HOME/rhash/rhashrc, $HOME/.rhashrc and /etc/rhashrc.
 
 The config file consists of lines formatted as
 .RS 

--- a/parse_cmdline.c
+++ b/parse_cmdline.c
@@ -526,7 +526,18 @@ static const char* find_conf_file(void)
 	char *dir1, *path;
 
 #ifndef _WIN32 /* Linux/Unix part */
-	/* first check for $HOME/.rhashrc file */
+	/* first check for $XDG_CONFIG_HOME/rhash/rhashrc file */
+	if ( (dir1 = getenv("XDG_CONFIG_HOME")) ) {
+		dir1 = make_path(dir1, "rhash");
+		path = make_path(dir1, CONFIG_FILENAME);
+		free(dir1);
+		if (is_regular_file(path)) {
+			rsh_vector_add_ptr(opt.mem, path);
+			return (conf_opt.config_file = path);
+		}
+		free(path);
+	}
+	/* then check for $HOME/.rhashrc file */
 	if ( (dir1 = getenv("HOME")) ) {
 		path = make_path(dir1, ".rhashrc");
 		if (is_regular_file(path)) {


### PR DESCRIPTION
This PR adds support for `$XDG_CONFIG_HOME/rhash/rhashrc` as config file [1].

BTW, I’m not sure about not further validating the `getenv()` result. When
intended as a feature to be able to load a config file from current directory:

```sh
cd /tmp/foo/
echo 'verbose = yes' > .rhashrc
HOME="" rhash --sha256 ./bar 
```

then, I think, it should be mentioned somewhere in the docs.


Reference:
  [1] <https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html>
