### PR TITLE
configure -

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,8 @@ install-conf:
 
 # dependencies should be properly set, otherwise 'make -j<n>' can fail
 install-symlinks: mkdir-bin install-man install-binary
-	cd $(BINDIR) && for f in $(SYMLINKS); do ln -fs $(RHASH_BINARY) $$f$(EXEC_EXT); done
-	cd $(MANDIR)/man1 && for f in $(SYMLINKS); do ln -fs rhash.1* $$f.1; done
+	cd $(BINDIR) && for f in $(SYMLINKS); do $(LN_S) $(RHASH_BINARY) $$f$(EXEC_EXT); done
+	cd $(MANDIR)/man1 && for f in $(SYMLINKS); do $(LN_S) rhash.1 $$f.1; done
 
 install-pkg-config:
 	$(INSTALL) -d $(PKGCONFIGDIR)
@@ -108,10 +108,10 @@ uninstall-lib:
 	+cd librhash && $(MAKE) uninstall-lib
 
 install-lib-static: $(LIBRHASH_STATIC)
-	+cd librhash && $(MAKE) install-lib-static
+	+cd librhash && $(MAKE) install-lib-static install-headers
 
 install-lib-shared: $(LIBRHASH_SHARED)
-	+cd librhash && $(MAKE) install-lib-shared
+	+cd librhash && $(MAKE) install-lib-shared install-headers
 
 install-lib-so-link:
 	+cd librhash && $(MAKE) install-so-link

--- a/configure
+++ b/configure
@@ -543,7 +543,9 @@ EXEC_EXT=
 NEED_IMPLIB=no
 NEED_SOLINK=yes
 INSTALL_SO_DIR=$INSTALL_LIBDIR
+LN_S="ln -sf"
 if win32; then
+  LN_S="cp -pR"
   EXEC_EXT=".exe"
   SHARED_EXT=".dll"
   NEED_IMPLIB=yes
@@ -645,11 +647,11 @@ if test "$OPT_GETTEXT" != "no"; then
   if cc_check_headers "libintl.h"; then
     if cc_check_statement "libintl.h" "gettext(\"\");"; then
       GETTEXT_FOUND=found
-    elif cc_check_statement "libintl.h" "gettext(\"\");" "-lintl"; then
-      GETTEXT_LDFLAGS="-lintl"
-      GETTEXT_FOUND=found
     elif cc_check_statement "libintl.h" "gettext(\"\");" "-lintl -liconv"; then
       GETTEXT_LDFLAGS="-lintl -liconv"
+      GETTEXT_FOUND=found
+    elif cc_check_statement "libintl.h" "gettext(\"\");" "-lintl"; then
+      GETTEXT_LDFLAGS="-lintl"
       GETTEXT_FOUND=found
     fi
   fi
@@ -811,6 +813,7 @@ RHASH_SHARED    = $RHASH_SHARED\$(EXEC_EXT)
 BUILD_TARGETS   = $RHASH_BUILD_TARGETS
 EXTRA_INSTALL   = $RHASH_EXTRA_INSTALL
 SYMLINKS        = $INSTALL_SYMLINKS
+LN_S            = $LN_S
 
 OPTFLAGS    = $OPTFLAGS
 OPTLDFLAGS  = $WIN_LDFLAGS

--- a/file.c
+++ b/file.c
@@ -18,7 +18,9 @@
 
 #if defined( _WIN32) || defined(__CYGWIN__)
 # include <windows.h>
+#if !defined(__CYGWIN__)
 # include <share.h> /* for _SH_DENYWR */
+#endif
 # include <fcntl.h>  /* _O_RDONLY, _O_BINARY */
 # include <io.h>
 #endif


### PR DESCRIPTION
   Detect for both iconv and gettext because in Windows, Gettext depends upon the iconv library
   Add logic for ln from autoconf.  On Win32 systems, it may not always work as you think and symbolic links are done the same way.  This can cause problems for deploymebnt and distributions of packages.
file.c - IFDEF out share.h for Cygwin and MSYS.  Those do not have this file.
Makefile - fix "symbolic links" for man file deployment.  They would sometimes fail because cp or ln thinks you copying more than one file to one target which is not permitted.
make install-lib-static and install-lib-shared also install the headers.  I did see some complaint from Archlinux about this and here as well.
embed the ln logic from configure script for reasons stated earlier.