### PR TITLE
configure: fix support for Solaris

### DIFF
--- a/configure
+++ b/configure
@@ -393,7 +393,7 @@ else
       bsd/os) TARGET_OS=BSD/OS ;;
       openbsd) TARGET_OS=OpenBSD ;;
       dragonfly) TARGET_OS=DragonFly ;;
-      sunos) TARGET_OS=SunOS ;;
+      sunos|solaris2.*) TARGET_OS=SunOS ;;
       qnx) TARGET_OS=QNX ;;
       morphos) TARGET_OS=MorphOS ;;
       amigaos) TARGET_OS=AmigaOS ;;


### PR DESCRIPTION
This fixes the following behaviour:

% gcc -dumpmachine
x86_64-pc-solaris2.11
% ./configure --target=x86_64-pc-solaris2.11
Checking for target OS ... UNKNOWN

Error: Unknown target OS, please specify the --target option

Check for solaris2* in the triplet, when --target is given.

Signed-off-by: Fabian Groffen <grobian@gentoo.org>