### PR TITLE
configure: fix support for Cygwin

### DIFF
--- a/configure
+++ b/configure
@@ -400,6 +400,7 @@ else
       mingw32*) TARGET_OS=MINGW32 ;;
       wine) TARGET_OS=Wine ;;
       darwin*) TARGET_OS=Darwin ;;
+      cygwin*) TARGET_OS=CYGWIN ;;
     esac
   }
   TARGET_OS="UNKNOWN"


### PR DESCRIPTION
Check for cygwin* in the triplet, when --target is given.

This fixes the following behaviour:
$ gcc -dumpmachine
x86_64-pc-cygwin

$ ./configure --target=x86_64-pc-cygwin
Checking for target OS ... UNKNOWN

Error: Unknown target OS, please specify the --target option

Signed-off-by: Michael Haubenwallner <michael.haubenwallner@ssi-schaefer.com>