### PR TITLE
librhash/Makefile: fix failure if link exist

### DIFF
--- a/librhash/Makefile
+++ b/librhash/Makefile
@@ -35,6 +35,7 @@ install-implib:
 
 install-so-link:
 	$(INSTALL) -d $(LIBDIR)
+	rm -f $(LIBDIR)/$(LIBRHASH_SOLINK)
 	ln -s $(LIBRHASH_SHARED) $(LIBDIR)/$(LIBRHASH_SOLINK)
 
 uninstall-lib-static: uninstall-lib-headers


### PR DESCRIPTION
Build will fail if librhash.so link already exist (for example due to a
prior install)

Fix this error by calling rm -f before ln -s as done by commit
123e9b76c80861e7648ccf99955c0dc5420d7297 for other links

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>