### PR TITLE
Bugfix: only follow symbolic links when --follow is specified

### DIFF
--- a/dist/rhash.1
+++ b/dist/rhash.1
@@ -120,7 +120,7 @@ file lists can be specified at command line.
 .IP "\-m, \-\-message=<text>"
 Calculate message digests of the given text message.
 .IP "\-\-follow"
-Follow symbolic links when processing directories recursively.
+Follow symbolic links when processing files or directories recursively.
 .IP "\-v, \-\-verbose"
 Be verbose.
 .IP "\-P, \-\-percents"

--- a/find_file.c
+++ b/find_file.c
@@ -459,7 +459,7 @@ static int dir_scan(file_t* start_dir, file_search_data* data)
 			filepath = make_tpath(dir_path, dirent_get_tname(de));
 			if (!filepath)
 				continue;
-			res  = file_init(&file, filepath, FileInitRunFstat | FileInitUpdatePrintPathLastSlash);
+			res  = file_init(&file, filepath, fstat_bit | FileInitUpdatePrintPathLastSlash);
 			free(filepath);
 			if (res >= 0)
 			{


### PR DESCRIPTION
Currently, we are following symbolic links when doing a recursive
descent through the directory tree even when --follow is not
specified.  This change does change behavior so that we don't follow
symlinks for both *directories* and *files* unless the --follow option
is specified.  This may or may not be what other users are depending
upon, since the documentation originally defines --follow as:

   Follow symbolic links when processing directories recursively.

There is _no_ other documentation describing how symlinks to regular
files are supposed to be handled.  So it's not clear to me whether is
wanted for symlinks to regular files.  However, for _my_ use, this is
actually what I want, so I'm just going to change the man page.

It may be that what there should be are separate options,
--follow-symlinked-dirs and --follow-symlinked-files, but that would
require a lstat() and a fstat() when a symlink is found so we can
disambiguate between these two cases.

Fixes-github-RHash-bug: #131
Signed-off-by: Theodore Ts'o <tytso@mit.edu>