### PR TITLE
Fix some pointer subtraction UBs

### DIFF
--- a/librhash/algorithms.c
+++ b/librhash/algorithms.c
@@ -104,8 +104,8 @@ rhash_info info_sha3_384 = { RHASH_SHA3_384, F_LE64, 48, "SHA3-384", "sha3-384" 
 rhash_info info_sha3_512 = { RHASH_SHA3_512, F_LE64, 64, "SHA3-512", "sha3-512" };
 
 /* some helper macros */
-#define dgshft(name) (((char*)&((name##_ctx*)0)->hash) - (char*)0)
-#define dgshft2(name, field) (((char*)&((name##_ctx*)0)->field) - (char*)0)
+#define dgshft(name) ((uintptr_t)((char*)&((name##_ctx*)0)->hash))
+#define dgshft2(name, field) ((uintptr_t)((char*)&((name##_ctx*)0)->field))
 #define ini(name) ((pinit_t)(name##_init))
 #define upd(name) ((pupdate_t)(name##_update))
 #define fin(name) ((pfinal_t)(name##_final))

--- a/librhash/byte_order.c
+++ b/librhash/byte_order.c
@@ -74,7 +74,7 @@ unsigned rhash_ctz(unsigned x)
 void rhash_swap_copy_str_to_u32(void* to, int index, const void* from, size_t length)
 {
 	/* if all pointers and length are 32-bits aligned */
-	if ( 0 == ( ((uintptr_t)to & 3) | ((uintptr_t)from & 3) | (index & 3) | (length & 3) ) ) {
+	if ( 0 == (( (uintptr_t)to | (uintptr_t)from | (uintptr_t)index | length ) & 3) ) {
 		/* copy memory as 32-bit words */
 		const uint32_t* src = (const uint32_t*)from;
 		const uint32_t* end = (const uint32_t*)((const char*)src + length);
@@ -101,7 +101,7 @@ void rhash_swap_copy_str_to_u32(void* to, int index, const void* from, size_t le
 void rhash_swap_copy_str_to_u64(void* to, int index, const void* from, size_t length)
 {
 	/* if all pointers and length are 64-bits aligned */
-	if ( 0 == ( ((uintptr_t)to & 7) | ((uintptr_t)from & 7) | (index & 7) | (length & 7) ) ) {
+	if ( 0 == (( (uintptr_t)to | (uintptr_t)from | (uintptr_t)index | length ) & 7) ) {
 		/* copy aligned memory block as 64-bit integers */
 		const uint64_t* src = (const uint64_t*)from;
 		const uint64_t* end = (const uint64_t*)((const char*)src + length);
@@ -124,7 +124,7 @@ void rhash_swap_copy_str_to_u64(void* to, int index, const void* from, size_t le
 void rhash_swap_copy_u64_to_str(void* to, const void* from, size_t length)
 {
 	/* if all pointers and length are 64-bits aligned */
-	if ( 0 == ( ((uintptr_t)to & 7) | ((uintptr_t)from & 7) | (length & 7) ) ) {
+	if ( 0 == (( (uintptr_t)to | (uintptr_t)from | length ) & 7) ) {
 		/* copy aligned memory block as 64-bit integers */
 		const uint64_t* src = (const uint64_t*)from;
 		const uint64_t* end = (const uint64_t*)((const char*)src + length);

--- a/librhash/byte_order.c
+++ b/librhash/byte_order.c
@@ -74,7 +74,7 @@ unsigned rhash_ctz(unsigned x)
 void rhash_swap_copy_str_to_u32(void* to, int index, const void* from, size_t length)
 {
 	/* if all pointers and length are 32-bits aligned */
-	if ( 0 == (( (int)((char*)to - (char*)0) | ((char*)from - (char*)0) | index | length ) & 3) ) {
+	if ( 0 == ( ((uintptr_t)to & 3) | ((uintptr_t)from & 3) | (index & 3) | (length & 3) ) ) {
 		/* copy memory as 32-bit words */
 		const uint32_t* src = (const uint32_t*)from;
 		const uint32_t* end = (const uint32_t*)((const char*)src + length);
@@ -101,7 +101,7 @@ void rhash_swap_copy_str_to_u32(void* to, int index, const void* from, size_t le
 void rhash_swap_copy_str_to_u64(void* to, int index, const void* from, size_t length)
 {
 	/* if all pointers and length are 64-bits aligned */
-	if ( 0 == (( (int)((char*)to - (char*)0) | ((char*)from - (char*)0) | index | length ) & 7) ) {
+	if ( 0 == ( ((uintptr_t)to & 7) | ((uintptr_t)from & 7) | (index & 7) | (length & 7) ) ) {
 		/* copy aligned memory block as 64-bit integers */
 		const uint64_t* src = (const uint64_t*)from;
 		const uint64_t* end = (const uint64_t*)((const char*)src + length);
@@ -124,7 +124,7 @@ void rhash_swap_copy_str_to_u64(void* to, int index, const void* from, size_t le
 void rhash_swap_copy_u64_to_str(void* to, const void* from, size_t length)
 {
 	/* if all pointers and length are 64-bits aligned */
-	if ( 0 == (( (int)((char*)to - (char*)0) | ((char*)from - (char*)0) | length ) & 7) ) {
+	if ( 0 == ( ((uintptr_t)to & 7) | ((uintptr_t)from & 7) | (length & 7) ) ) {
 		/* copy aligned memory block as 64-bit integers */
 		const uint64_t* src = (const uint64_t*)from;
 		const uint64_t* end = (const uint64_t*)((const char*)src + length);

--- a/librhash/byte_order.h
+++ b/librhash/byte_order.h
@@ -81,8 +81,8 @@ extern "C" {
 # define __has_builtin(x) 0
 #endif
 
-#define IS_ALIGNED_32(p) (0 == (3 & ((const char*)(p) - (const char*)0)))
-#define IS_ALIGNED_64(p) (0 == (7 & ((const char*)(p) - (const char*)0)))
+#define IS_ALIGNED_32(p) (0 == (3 & ((uintptr_t)(p))))
+#define IS_ALIGNED_64(p) (0 == (7 & ((uintptr_t)(p))))
 
 #if defined(_MSC_VER)
 #define ALIGN_ATTR(n) __declspec(align(n))

--- a/librhash/byte_order.h
+++ b/librhash/byte_order.h
@@ -81,8 +81,8 @@ extern "C" {
 # define __has_builtin(x) 0
 #endif
 
-#define IS_ALIGNED_32(p) (0 == (3 & ((uintptr_t)(p))))
-#define IS_ALIGNED_64(p) (0 == (7 & ((uintptr_t)(p))))
+#define IS_ALIGNED_32(p) (0 == (3 & (uintptr_t)(p)))
+#define IS_ALIGNED_64(p) (0 == (7 & (uintptr_t)(p)))
 
 #if defined(_MSC_VER)
 #define ALIGN_ATTR(n) __declspec(align(n))

--- a/librhash/crc32.c
+++ b/librhash/crc32.c
@@ -35,7 +35,7 @@ static unsigned calculate_crc_soft(unsigned crcinit, unsigned table[8][256], con
 	const uint32_t* current;
 
 	/* process not aligned message head */
-	for (; (3 & ((uintptr_t)msg)) && size > 0; msg++, size--)
+	for (; (3 & (uintptr_t)msg) && size > 0; msg++, size--)
 		crc = table[0][(crc & 0xFF) ^ *msg] ^ (crc >> 8);
 
 	/* process aligned part */

--- a/librhash/crc32.c
+++ b/librhash/crc32.c
@@ -35,7 +35,7 @@ static unsigned calculate_crc_soft(unsigned crcinit, unsigned table[8][256], con
 	const uint32_t* current;
 
 	/* process not aligned message head */
-	for (; (3 & (msg - (unsigned char*)0)) && size > 0; msg++, size--)
+	for (; (3 & ((uintptr_t)msg)) && size > 0; msg++, size--)
 		crc = table[0][(crc & 0xFF) ^ *msg] ^ (crc >> 8);
 
 	/* process aligned part */

--- a/librhash/util.h
+++ b/librhash/util.h
@@ -27,7 +27,6 @@ extern "C" {
 /* alignment macros */
 #define DEFAULT_ALIGNMENT 64
 #define ALIGN_SIZE_BY(size, align) (((size) + ((align) - 1)) & ~((align) - 1))
-#define ALIGN_PTR_BY(ptr, align) ((char*)(ptr) + (((char*)0 - (char*)(ptr)) & ((align) - 1))))
 #define IS_SIZE_ALIGNED_BY(size, align) (((size) & ((align) - 1)) == 0)
 #define IS_PTR_ALIGNED_BY(ptr, align) IS_SIZE_ALIGNED_BY((uintptr_t)(ptr), (align))
 

--- a/librhash/util.h
+++ b/librhash/util.h
@@ -29,7 +29,7 @@ extern "C" {
 #define ALIGN_SIZE_BY(size, align) (((size) + ((align) - 1)) & ~((align) - 1))
 #define ALIGN_PTR_BY(ptr, align) ((char*)(ptr) + (((char*)0 - (char*)(ptr)) & ((align) - 1))))
 #define IS_SIZE_ALIGNED_BY(size, align) (((size) & ((align) - 1)) == 0)
-#define IS_PTR_ALIGNED_BY(ptr, align) IS_SIZE_ALIGNED_BY((char*)(ptr) - (char*)0, (align))
+#define IS_PTR_ALIGNED_BY(ptr, align) IS_SIZE_ALIGNED_BY((uintptr_t)(ptr), (align))
 
 /* define rhash_aligned_alloc() and rhash_aligned_free() */
 #if defined(_WIN32)


### PR DESCRIPTION
Fix pointer arithmetic operations which subtract the NULL pointer from another valid pointer.

The results of such subtractions are undefined according to the C standard (see [C17#6.5.6.p9](https://cigix.me/c17#6.5.6.p9)). Casting to `uintptr_t` is a standard-compliant way to express the intended behavior here.