### PR TITLE
Make the field vector in rhash_context_ext a flexible array member

### DIFF
--- a/librhash/algorithms.h
+++ b/librhash/algorithms.h
@@ -87,7 +87,7 @@ typedef struct rhash_context_ext
 	void* callback;
 	void* callback_data;
 	void* bt_ctx;
-	rhash_vector_item vector[1]; /* contexts of contained hash sums */
+	rhash_vector_item vector[]; /* contexts of contained hash sums */
 } rhash_context_ext;
 
 extern rhash_hash_info rhash_hash_info_default[RHASH_HASH_COUNT];

--- a/librhash/rhash.c
+++ b/librhash/rhash.c
@@ -80,7 +80,7 @@ static rhash rhash_init_multi(size_t count, unsigned hash_ids[])
 {
 	struct rhash_hash_info* info;   /* hash algorithm information */
 	rhash_context_ext* rctx = NULL; /* allocated rhash context */
-	const size_t header_size = GET_ALIGNED_SIZE(sizeof(rhash_context_ext) + sizeof(rhash_vector_item) * (count - 1));
+	const size_t header_size = GET_ALIGNED_SIZE(sizeof(rhash_context_ext) + sizeof(rhash_vector_item) * count);
 	size_t ctx_size_sum = 0;   /* size of hash contexts to store in rctx */
 	size_t i;
 	char* phash_ctx;


### PR DESCRIPTION
Defining `rhash_vector_item vector` with length `1` makes all accesses beyond index `0` undefined - these are technically out of bound accesses.

The standard-compliant way is to use the *flexible array member*, as defined here: [c17#6.7.2.1.p18](https://cigix.me/c17#6.7.2.1.p18).

NOTE: After this change the field `vector` does not contribute to the result of `sizeof(rhash_context_ext)` anymore, so this has to be adjusted.