### PR TITLE
Fix a pointer arithmetic UB

### DIFF
--- a/file.c
+++ b/file.c
@@ -62,8 +62,8 @@ static const char* get_basename(const char* path)
 	const char* p;
 	if (!path)
 		return NULL;
-	for (p = path + strlen(path) - 1; p >= path && !IS_PATH_SEPARATOR(*p); p--);
-	return (p + 1);
+	for (p = path + strlen(path); p > path && !IS_PATH_SEPARATOR(*(p - 1)); p--);
+	return p;
 }
 
 /**


### PR DESCRIPTION
Fix the computation in order to avoid Undefined Behavior caused by computing a invalid pointer (one-behind the beginning of the `path` string).