### PR TITLE
Fix memcpy call with an invalid argument

### DIFF
--- a/librhash/tiger.c
+++ b/librhash/tiger.c
@@ -167,7 +167,8 @@ void rhash_tiger_update(tiger_ctx* ctx, const unsigned char* msg, size_t size)
 	if (index) {
 		size_t left = tiger_block_size - index;
 		if (size < left) {
-			memcpy(ctx->message + index, msg, size);
+			if (size > 0)
+				memcpy(ctx->message + index, msg, size);
 			return;
 		} else {
 			memcpy(ctx->message + index, msg, left);


### PR DESCRIPTION
Calling `memcpy` with invalid argument `mem` causes Undefined Behavior even if the `size` argument is equal 0.

This is a little-known Undefined Behavior (see [C17#7.1.4.p1](https://cigix.me/c17#7.1.4.p1) and [C17#7.24.1.p2](https://cigix.me/c17#7.24.1.p2)), but actually exploited by some compiler optimizations.