### PR TITLE
Workaround / fix for uninitialized memory accesses

### DIFF
--- a/librhash/rhash.c
+++ b/librhash/rhash.c
@@ -111,7 +111,7 @@ static rhash rhash_init_multi(size_t count, unsigned hash_ids[])
 		return NULL;
 
 	/* initialize common fields of the rhash context */
-	memset(rctx, 0, header_size);
+	memset(rctx, 0, GET_ALIGNED_SIZE(header_size + ctx_size_sum));
 	rctx->rc.hash_id = hash_bitmask;
 	rctx->flags = RCTX_AUTO_FINAL; /* turn on auto-final by default */
 	rctx->state = STATE_ACTIVE;


### PR DESCRIPTION
The related Undefined Behaviors could be pretty serious, as the program is actually reading uninitialized memory. But I didn't manage pinpoint the exact cause, so my solution is just initializing it all to 0 at the beginning. Which may be the way to go or not - it's up to you to decide.

Initially I was guessing that this happens when the input message is very short (as in one case it happens for the "abc" example when doing `&=` [at line 216 of the file `md5.c`](https://github.com/rhash/RHash/blob/master/librhash/md5.c#L216)), but actually there are many other cases. This seems to be happening in various similar places, maybe there is one common root cause or not. If you want to explore this, you can see all the discovered cases here: https://ci.trust-in-soft.com/projects/jakub-zwolakowski/RHash/7

Or maybe the initialization workaround I propose is actually a good fix. Especially if you think that there are no underlying problems here and just sometimes some superfluous operations (which do not affect the program's results nor its control flow) are performed on uninitialized memory.