### PR TITLE
Fix another pointer arithmetic UB

### DIFF
--- a/librhash/torrent.c
+++ b/librhash/torrent.c
@@ -362,7 +362,8 @@ static void bt_bencode_pieces(torrent_ctx* ctx)
 	{
 		memcpy(p, ctx->hash_blocks.array[i],
 			(size < BT_BLOCK_SIZE ? size : BT_BLOCK_SIZE) * BT_HASH_SIZE);
-		p += BT_BLOCK_SIZE * BT_HASH_SIZE;
+		if (size > BT_BLOCK_SIZE)
+			p += BT_BLOCK_SIZE * BT_HASH_SIZE;
 	}
 }
 


### PR DESCRIPTION
Fix the computation in order to avoid Undefined Behavior caused by computing a invalid pointer in the last iteration of the loop (`p` pointing outside the memory zone allocated pointed by `ctx->content.str`).

My patch fixes the problem, but it's not very elegant... There must be a better way to avoid this invalid computation in the last iteration here.