### PR TITLE
configure: add uclinux target

### DIFF
--- a/configure
+++ b/configure
@@ -427,7 +427,7 @@ else
     component=$1
     part=$(echo $BUILD_TARGET | cut -d '-' -f $component)
     case "$(echo $part | tr '[A-Z]' '[a-z]')" in
-      linux) TARGET_OS=Linux ;;
+      linux|uclinux) TARGET_OS=Linux ;;
       freebsd*) TARGET_OS=FreeBSD ;;
       gnu/kfreebsd) TARGET_OS=FreeBSD ;;
       netbsd) TARGET_OS=NetBSD ;;


### PR DESCRIPTION
Fix the following build failure with `--target=arm-buildroot-uclinux-uclibcgnueabi`:

```
Checking for target OS ... UNKNOWN

Error: Unknown target OS, please specify the --target option
```

Fixes:
 - http://autobuild.buildroot.org/results/598ca65cf0c7ecf9ceaecb75868b656570ae00d2

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>