### PR TITLE
Specify bash as interpreter for configure

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # set default values
 OPT_OPENSSL=auto


### PR DESCRIPTION
$RANDOM is a bash builtin, and the behavior
isn't standard for other shell interpreters.

Ran into this issue trying in a cross-compile situation, where the default `sh` is a minimal implementation.