### PR TITLE
Unroll SHA-1 code with a significant speedup

### DIFF
--- a/librhash/sha1.c
+++ b/librhash/sha1.c
@@ -47,12 +47,10 @@ static const uint32_t K3 = 0xca62c1d6;
 #define PAR(X,Y,Z) ((X)^(Y)^(Z))
 #define MAJ(X,Y,Z) (((X)&(Y))|((X)&(Z))|((Y)&(Z)))
 
-#define ROUND(a,b,c,d,e, FF, k, w)              \
-	do {                                    \
-		e += FF(b,c,d)+ROTL32(a,5)+k+w; \
-		b = ROTL32(b,30);               \
-	} while (0)
-
+#define ROUND_0(a,b,c,d,e, FF, k, w) e +=              FF(b,       c,           d    )+ROTL32(a,5)+k+w
+#define ROUND_1(a,b,c,d,e, FF, k, w) e +=              FF(b,ROTL32(c,30),       d    )+ROTL32(a,5)+k+w
+#define ROUND_2(a,b,c,d,e, FF, k, w) e +=              FF(b,ROTL32(c,30),ROTL32(d,30))+ROTL32(a,5)+k+w
+#define ROUND(a,b,c,d,e, FF, k, w) e  = ROTL32(e,30)+FF(b,ROTL32(c,30),ROTL32(d,30))+ROTL32(a,5)+k+w
 
 
 /**
@@ -76,11 +74,11 @@ static void rhash_sha1_process_block(unsigned* hash, const unsigned* block)
 
 	/* 0..19 */
 	W[ 0] = be2me_32(block[ 0]);
-	ROUND(A,B,C,D,E, CHO, K0, W[ 0]);
+	ROUND_0(A,B,C,D,E, CHO, K0, W[ 0]);
 	W[ 1] = be2me_32(block[ 1]);
-	ROUND(E,A,B,C,D, CHO, K0, W[ 1]);
+	ROUND_1(E,A,B,C,D, CHO, K0, W[ 1]);
 	W[ 2] = be2me_32(block[ 2]);
-	ROUND(D,E,A,B,C, CHO, K0, W[ 2]);
+	ROUND_2(D,E,A,B,C, CHO, K0, W[ 2]);
 	W[ 3] = be2me_32(block[ 3]);
 	ROUND(C,D,E,A,B, CHO, K0, W[ 3]);
 	W[ 4] = be2me_32(block[ 4]);
@@ -254,9 +252,9 @@ static void rhash_sha1_process_block(unsigned* hash, const unsigned* block)
 
 	hash[0] += A;
 	hash[1] += B;
-	hash[2] += C;
-	hash[3] += D;
-	hash[4] += E;
+	hash[2] += ROTL32(C,30);
+	hash[3] += ROTL32(D,30);
+	hash[4] += ROTL32(E,30);
 }
 
 /**

--- a/librhash/sha1.c
+++ b/librhash/sha1.c
@@ -36,6 +36,25 @@ void rhash_sha1_init(sha1_ctx* ctx)
 	ctx->hash[4] = 0xc3d2e1f0;
 }
 
+/* constants for SHA1 rounds */
+static const uint32_t K0 = 0x5a827999;
+static const uint32_t K1 = 0x6ed9eba1;
+static const uint32_t K2 = 0x8f1bbcdc;
+static const uint32_t K3 = 0xca62c1d6;
+
+/* round functions for SHA1 */
+#define CHO(X,Y,Z) (((X)&(Y))|((~(X))&(Z)))
+#define PAR(X,Y,Z) ((X)^(Y)^(Z))
+#define MAJ(X,Y,Z) (((X)&(Y))|((X)&(Z))|((Y)&(Z)))
+
+#define ROUND(a,b,c,d,e, FF, k, w)              \
+	do {                                    \
+		e += FF(b,c,d)+ROTL32(a,5)+k+w; \
+		b = ROTL32(b,30);               \
+	} while (0)
+
+
+
 /**
  * The core transformation. Process a 512-bit block.
  * The function has been taken from RFC 3174 with little changes.
@@ -45,21 +64,9 @@ void rhash_sha1_init(sha1_ctx* ctx)
  */
 static void rhash_sha1_process_block(unsigned* hash, const unsigned* block)
 {
-	int           t;                 /* Loop counter */
-	uint32_t      temp;              /* Temporary word value */
 	uint32_t      W[80];             /* Word sequence */
 	uint32_t      A, B, C, D, E;     /* Word buffers */
 
-	/* initialize the first 16 words in the array W */
-	for (t = 0; t < 16; t++) {
-		/* note: it is much faster to apply be2me here, then using be32_copy */
-		W[t] = be2me_32(block[t]);
-	}
-
-	/* initialize the rest */
-	for (t = 16; t < 80; t++) {
-		W[t] = ROTL32(W[t - 3] ^ W[t - 8] ^ W[t - 14] ^ W[t - 16], 1);
-	}
 
 	A = hash[0];
 	B = hash[1];
@@ -67,44 +74,183 @@ static void rhash_sha1_process_block(unsigned* hash, const unsigned* block)
 	D = hash[3];
 	E = hash[4];
 
-	for (t = 0; t < 20; t++) {
-		/* the following is faster than ((B & C) | ((~B) & D)) */
-		temp =  ROTL32(A, 5) + (((C ^ D) & B) ^ D)
-			+ E + W[t] + 0x5A827999;
-		E = D;
-		D = C;
-		C = ROTL32(B, 30);
-		B = A;
-		A = temp;
-	}
+	/* 0..19 */
+	W[ 0] = be2me_32(block[ 0]);
+	ROUND(A,B,C,D,E, CHO, K0, W[ 0]);
+	W[ 1] = be2me_32(block[ 1]);
+	ROUND(E,A,B,C,D, CHO, K0, W[ 1]);
+	W[ 2] = be2me_32(block[ 2]);
+	ROUND(D,E,A,B,C, CHO, K0, W[ 2]);
+	W[ 3] = be2me_32(block[ 3]);
+	ROUND(C,D,E,A,B, CHO, K0, W[ 3]);
+	W[ 4] = be2me_32(block[ 4]);
+	ROUND(B,C,D,E,A, CHO, K0, W[ 4]);
 
-	for (t = 20; t < 40; t++) {
-		temp = ROTL32(A, 5) + (B ^ C ^ D) + E + W[t] + 0x6ED9EBA1;
-		E = D;
-		D = C;
-		C = ROTL32(B, 30);
-		B = A;
-		A = temp;
-	}
+	W[ 5] = be2me_32(block[ 5]);
+	ROUND(A,B,C,D,E, CHO, K0, W[ 5]);
+	W[ 6] = be2me_32(block[ 6]);
+	ROUND(E,A,B,C,D, CHO, K0, W[ 6]);
+	W[ 7] = be2me_32(block[ 7]);
+	ROUND(D,E,A,B,C, CHO, K0, W[ 7]);
+	W[ 8] = be2me_32(block[ 8]);
+	ROUND(C,D,E,A,B, CHO, K0, W[ 8]);
+	W[ 9] = be2me_32(block[ 9]);
+	ROUND(B,C,D,E,A, CHO, K0, W[ 9]);
+              
+	W[10] = be2me_32(block[10]);
+	ROUND(A,B,C,D,E, CHO, K0, W[10]);
+	W[11] = be2me_32(block[11]);
+	ROUND(E,A,B,C,D, CHO, K0, W[11]);
+	W[12] = be2me_32(block[12]);
+	ROUND(D,E,A,B,C, CHO, K0, W[12]);
+	W[13] = be2me_32(block[13]);
+	ROUND(C,D,E,A,B, CHO, K0, W[13]);
+	W[14] = be2me_32(block[14]);
+	ROUND(B,C,D,E,A, CHO, K0, W[14]);
+           
+	W[15] = be2me_32(block[15]);
+	ROUND(A,B,C,D,E, CHO, K0, W[15]);
+	W[16] = ROTL32(W[13] ^ W[ 8] ^ W[ 2] ^ W[ 0], 1);
+	ROUND(E,A,B,C,D, CHO, K0, W[16]);
+	W[17] = ROTL32(W[14] ^ W[ 9] ^ W[ 3] ^ W[ 1], 1);
+	ROUND(D,E,A,B,C, CHO, K0, W[17]);
+	W[18] = ROTL32(W[15] ^ W[10] ^ W[ 4] ^ W[ 2], 1);
+	ROUND(C,D,E,A,B, CHO, K0, W[18]);
+	W[19] = ROTL32(W[16] ^ W[11] ^ W[ 5] ^ W[ 3], 1);
+	ROUND(B,C,D,E,A, CHO, K0, W[19]);
+	/* 20..39 */
+	W[20] = ROTL32(W[17] ^ W[12] ^ W[ 6] ^ W[ 4], 1);
+	ROUND(A,B,C,D,E, PAR, K1, W[20]);
+	W[21] = ROTL32(W[18] ^ W[13] ^ W[ 7] ^ W[ 5], 1);
+	ROUND(E,A,B,C,D, PAR, K1, W[21]);
+	W[22] = ROTL32(W[19] ^ W[14] ^ W[ 8] ^ W[ 6], 1);
+	ROUND(D,E,A,B,C, PAR, K1, W[22]);
+	W[23] = ROTL32(W[20] ^ W[15] ^ W[ 9] ^ W[ 7], 1);
+	ROUND(C,D,E,A,B, PAR, K1, W[23]);
+	W[24] = ROTL32(W[21] ^ W[16] ^ W[10] ^ W[ 8], 1);
+	ROUND(B,C,D,E,A, PAR, K1, W[24]);
 
-	for (t = 40; t < 60; t++) {
-		temp = ROTL32(A, 5) + ((B & C) | (B & D) | (C & D))
-			+ E + W[t] + 0x8F1BBCDC;
-		E = D;
-		D = C;
-		C = ROTL32(B, 30);
-		B = A;
-		A = temp;
-	}
+	W[25] = ROTL32(W[22] ^ W[17] ^ W[11] ^ W[ 9], 1);
+	ROUND(A,B,C,D,E, PAR, K1, W[25]);
+	W[26] = ROTL32(W[23] ^ W[18] ^ W[12] ^ W[10], 1);
+	ROUND(E,A,B,C,D, PAR, K1, W[26]);
+	W[27] = ROTL32(W[24] ^ W[19] ^ W[13] ^ W[11], 1);
+	ROUND(D,E,A,B,C, PAR, K1, W[27]);
+	W[28] = ROTL32(W[25] ^ W[20] ^ W[14] ^ W[12], 1);
+	ROUND(C,D,E,A,B, PAR, K1, W[28]);
+	W[29] = ROTL32(W[26] ^ W[21] ^ W[15] ^ W[13], 1);
+	ROUND(B,C,D,E,A, PAR, K1, W[29]);
 
-	for (t = 60; t < 80; t++) {
-		temp = ROTL32(A, 5) + (B ^ C ^ D) + E + W[t] + 0xCA62C1D6;
-		E = D;
-		D = C;
-		C = ROTL32(B, 30);
-		B = A;
-		A = temp;
-	}
+	W[30] = ROTL32(W[27] ^ W[22] ^ W[16] ^ W[14], 1);
+	ROUND(A,B,C,D,E, PAR, K1, W[30]);
+	W[31] = ROTL32(W[28] ^ W[23] ^ W[17] ^ W[15], 1);
+	ROUND(E,A,B,C,D, PAR, K1, W[31]);
+	W[32] = ROTL32(W[29] ^ W[24] ^ W[18] ^ W[16], 1);
+	ROUND(D,E,A,B,C, PAR, K1, W[32]);
+	W[33] = ROTL32(W[30] ^ W[25] ^ W[19] ^ W[17], 1);
+	ROUND(C,D,E,A,B, PAR, K1, W[33]);
+	W[34] = ROTL32(W[31] ^ W[26] ^ W[20] ^ W[18], 1);
+	ROUND(B,C,D,E,A, PAR, K1, W[34]);
+
+	W[35] = ROTL32(W[32] ^ W[27] ^ W[21] ^ W[19], 1);
+	ROUND(A,B,C,D,E, PAR, K1, W[35]);
+	W[36] = ROTL32(W[33] ^ W[28] ^ W[22] ^ W[20], 1);
+	ROUND(E,A,B,C,D, PAR, K1, W[36]);
+	W[37] = ROTL32(W[34] ^ W[29] ^ W[23] ^ W[21], 1);
+	ROUND(D,E,A,B,C, PAR, K1, W[37]);
+	W[38] = ROTL32(W[35] ^ W[30] ^ W[24] ^ W[22], 1);
+	ROUND(C,D,E,A,B, PAR, K1, W[38]);
+	W[39] = ROTL32(W[36] ^ W[31] ^ W[25] ^ W[23], 1);
+	ROUND(B,C,D,E,A, PAR, K1, W[39]);
+	/* 40..59 */
+	W[40] = ROTL32(W[37] ^ W[32] ^ W[26] ^ W[24], 1);
+	ROUND(A,B,C,D,E, MAJ, K2, W[40]);
+	W[41] = ROTL32(W[38] ^ W[33] ^ W[27] ^ W[25], 1);
+	ROUND(E,A,B,C,D, MAJ, K2, W[41]);
+	W[42] = ROTL32(W[39] ^ W[34] ^ W[28] ^ W[26], 1);
+	ROUND(D,E,A,B,C, MAJ, K2, W[42]);
+	W[43] = ROTL32(W[40] ^ W[35] ^ W[29] ^ W[27], 1);
+	ROUND(C,D,E,A,B, MAJ, K2, W[43]);
+	W[44] = ROTL32(W[41] ^ W[36] ^ W[30] ^ W[28], 1);
+	ROUND(B,C,D,E,A, MAJ, K2, W[44]);
+
+	W[45] = ROTL32(W[42] ^ W[37] ^ W[31] ^ W[29], 1);
+	ROUND(A,B,C,D,E, MAJ, K2, W[45]);
+	W[46] = ROTL32(W[43] ^ W[38] ^ W[32] ^ W[30], 1);
+	ROUND(E,A,B,C,D, MAJ, K2, W[46]);
+	W[47] = ROTL32(W[44] ^ W[39] ^ W[33] ^ W[31], 1);
+	ROUND(D,E,A,B,C, MAJ, K2, W[47]);
+	W[48] = ROTL32(W[45] ^ W[40] ^ W[34] ^ W[32], 1);
+	ROUND(C,D,E,A,B, MAJ, K2, W[48]);
+	W[49] = ROTL32(W[46] ^ W[41] ^ W[35] ^ W[33], 1);
+	ROUND(B,C,D,E,A, MAJ, K2, W[49]);
+
+	W[50] = ROTL32(W[47] ^ W[42] ^ W[36] ^ W[34], 1);
+	ROUND(A,B,C,D,E, MAJ, K2, W[50]);
+	W[51] = ROTL32(W[48] ^ W[43] ^ W[37] ^ W[35], 1);
+	ROUND(E,A,B,C,D, MAJ, K2, W[51]);
+	W[52] = ROTL32(W[49] ^ W[44] ^ W[38] ^ W[36], 1);
+	ROUND(D,E,A,B,C, MAJ, K2, W[52]);
+	W[53] = ROTL32(W[50] ^ W[45] ^ W[39] ^ W[37], 1);
+	ROUND(C,D,E,A,B, MAJ, K2, W[53]);
+	W[54] = ROTL32(W[51] ^ W[46] ^ W[40] ^ W[38], 1);
+	ROUND(B,C,D,E,A, MAJ, K2, W[54]);
+
+	W[55] = ROTL32(W[52] ^ W[47] ^ W[41] ^ W[39], 1);
+	ROUND(A,B,C,D,E, MAJ, K2, W[55]);
+	W[56] = ROTL32(W[53] ^ W[48] ^ W[42] ^ W[40], 1);
+	ROUND(E,A,B,C,D, MAJ, K2, W[56]);
+	W[57] = ROTL32(W[54] ^ W[49] ^ W[43] ^ W[41], 1);
+	ROUND(D,E,A,B,C, MAJ, K2, W[57]);
+	W[58] = ROTL32(W[55] ^ W[50] ^ W[44] ^ W[42], 1);
+	ROUND(C,D,E,A,B, MAJ, K2, W[58]);
+	W[59] = ROTL32(W[56] ^ W[51] ^ W[45] ^ W[43], 1);
+	ROUND(B,C,D,E,A, MAJ, K2, W[59]);
+	/* 60..79 */
+	W[60] = ROTL32(W[57] ^ W[52] ^ W[46] ^ W[44], 1);
+	ROUND(A,B,C,D,E, PAR, K3, W[60]);
+	W[61] = ROTL32(W[58] ^ W[53] ^ W[47] ^ W[45], 1);
+	ROUND(E,A,B,C,D, PAR, K3, W[61]);
+	W[62] = ROTL32(W[59] ^ W[54] ^ W[48] ^ W[46], 1);
+	ROUND(D,E,A,B,C, PAR, K3, W[62]);
+	W[63] = ROTL32(W[60] ^ W[55] ^ W[49] ^ W[47], 1);
+	ROUND(C,D,E,A,B, PAR, K3, W[63]);
+	W[64] = ROTL32(W[61] ^ W[56] ^ W[50] ^ W[48], 1);
+	ROUND(B,C,D,E,A, PAR, K3, W[64]);
+       
+	W[65] = ROTL32(W[62] ^ W[57] ^ W[51] ^ W[49], 1);
+	ROUND(A,B,C,D,E, PAR, K3, W[65]);
+	W[66] = ROTL32(W[63] ^ W[58] ^ W[52] ^ W[50], 1);
+	ROUND(E,A,B,C,D, PAR, K3, W[66]);
+	W[67] = ROTL32(W[64] ^ W[59] ^ W[53] ^ W[51], 1);
+	ROUND(D,E,A,B,C, PAR, K3, W[67]);
+	W[68] = ROTL32(W[65] ^ W[60] ^ W[54] ^ W[52], 1);
+	ROUND(C,D,E,A,B, PAR, K3, W[68]);
+	W[69] = ROTL32(W[66] ^ W[61] ^ W[55] ^ W[53], 1);
+	ROUND(B,C,D,E,A, PAR, K3, W[69]);
+
+	W[70] = ROTL32(W[67] ^ W[62] ^ W[56] ^ W[54], 1);
+	ROUND(A,B,C,D,E, PAR, K3, W[70]);
+	W[71] = ROTL32(W[68] ^ W[63] ^ W[57] ^ W[55], 1);
+	ROUND(E,A,B,C,D, PAR, K3, W[71]);
+	W[72] = ROTL32(W[69] ^ W[64] ^ W[58] ^ W[56], 1);
+	ROUND(D,E,A,B,C, PAR, K3, W[72]);
+	W[73] = ROTL32(W[70] ^ W[65] ^ W[59] ^ W[57], 1);
+	ROUND(C,D,E,A,B, PAR, K3, W[73]);
+	W[74] = ROTL32(W[71] ^ W[66] ^ W[60] ^ W[58], 1);
+	ROUND(B,C,D,E,A, PAR, K3, W[74]);
+
+	W[75] = ROTL32(W[72] ^ W[67] ^ W[61] ^ W[59], 1);
+	ROUND(A,B,C,D,E, PAR, K3, W[75]);
+	W[76] = ROTL32(W[73] ^ W[68] ^ W[62] ^ W[60], 1);
+	ROUND(E,A,B,C,D, PAR, K3, W[76]);
+	W[77] = ROTL32(W[74] ^ W[69] ^ W[63] ^ W[61], 1);
+	ROUND(D,E,A,B,C, PAR, K3, W[77]);
+	W[78] = ROTL32(W[75] ^ W[70] ^ W[64] ^ W[62], 1);
+	ROUND(C,D,E,A,B, PAR, K3, W[78]);
+	W[79] = ROTL32(W[76] ^ W[71] ^ W[65] ^ W[63], 1);
+	ROUND(B,C,D,E,A, PAR, K3, W[79]);
+
 
 	hash[0] += A;
 	hash[1] += B;


### PR DESCRIPTION
There are two commits in this pull request: first is a plain unroll, second is a small modification to the round function that gives considerable boost on newer CPUs.

Some benchmarkings:


build:
$ ./configure --disable-openssl --enable-static
$ make

build for 32bit:
$ ./configure --disable-openssl --enable-static --extra-cflags=-m32 --extra-ldflags=-m32
$ make


test:
$ dd if=/dev/zero bs=128k count=8k status=progress | taskset 0x01 ./rhash --sha1 -

tests are made with original rhash (orig), unrolled (unroll) and with modified rounds (mod), the numbers are not very accurate and are only provided to compare unrolled and modified code with original.

```
CPU: ryzen 9 5950x, 64bit, gcc 11.2.0
orig:   478 Mb/s
unroll: 990 Mb/s
mod:    1.0 Gb/s

CPU: ryzen 9 5950x, 32bit, gcc 11.2.0
orig:   475 Mb/s
unroll: 875 Mb/s
mod:    920 Mb/s


CPU: amd fx 8320, 64bit, gcc 9.3.0
orig:   200 Mb/s
unroll: 351 Mb/s
mod:    353 Mb/s

CPU: amd fx 8320, 32bit, gcc 9.3.0
orig:   181 Mb/s
unroll: 305 Mb/s
mod:    303 Mb/s


CPU: amd turion II mobile M520, 64bit, gcc 9.3.0
orig:   124 Mb/s
unroll: 230 Mb/s
mod:    228 Mb/s

CPU: amd turion II mobile M520, 32bit, gcc 9.3.0
orig:   133 Mb/s
unroll: 208 Mb/s
mod:    210 Mb/s


CPU: ryzen 5 5600H, 64bit, gcc 11.2.0
orig:   406 Mb/s
unroll: 825 Mb/s
mod:    850 Mb/s

CPU: ryzen 5 5600H, 32bit, gcc 11.2.0
orig:   404 Mb/s
unroll: 746 Mb/s
mod:    770 Mb/s


CPU: intel core i7-3770, 64bit, gcc 8.3.0
orig:   255 Mb/s
unroll: 507 Mb/s
mod:    515 Mb/s


CPU: intel atom D2700, 64bit, gcc 9.3.0
orig:   59.6 Mb/s
unroll: 103 Mb/s
mod:    103 Mb/s

CPU: intel atom D2700, 32bit, gcc 9.3.0
orig:   56.2 Mb/s
unroll: 90.5 Mb/s
mod:    90.7 Mb/s


CPU: cortex-a53, 64bit, clang 13.0.0 
orig:    52 Mb/s
unroll: 108 Mb/s
mod:    106 Mb/s

CPU: cortex-a73, 64bit, clang 13.0.0 
orig:   101 Mb/s
unroll: 180 Mb/s
mod:    180 Mb/s


CPU: intel xeon e5-2680 v3, 64bit, gcc 8.4.0
orig:   214 Mb/s
unroll: 428 Mb/s
mod:    442 Mb/s


CPU: intel core i3-5010U, 64bit, gcc 11.2.0
orig:   137 Mb/s
unroll: 270 Mb/s
mod:    273 Mb/s

CPU: intel core i3-5010U, 32bit, gcc 11.2.0
orig:   131 Mb/s
unroll: 242 Mb/s
mod:    244 Mb/s


CPU: intel celeron M 353, 32bit, gcc 7.5.0
orig:    46 Mb/s
unroll:  73 Mb/s
mod:     72 Mb/s

```