### PR TITLE
Add libcrypto.so.3 to the list of library names in plug_openssl.c

### DIFF
--- a/librhash/plug_openssl.c
+++ b/librhash/plug_openssl.c
@@ -212,6 +212,7 @@ static int load_openssl_runtime(void)
 #else
 	static const char* libNames[] = {
 		"libcrypto.so",
+		"libcrypto.so.3",
 		"libcrypto.so.1.1",
 		"libcrypto.so.1.0.2",
 		"libcrypto.so.1.0.0",


### PR DESCRIPTION
The SHA1_Update/Final functions are deprecated in openssl 3 but they are still there...