### PR TITLE
Fix -Wl,--no-undefined-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /dist/rhash.spec
 /dist/rhash.1.*
 /dist/librhash.pc
-/librhash/exports.sym
 po/*.gmo
 /rhash
 /rhash_shared

--- a/librhash/Makefile
+++ b/librhash/Makefile
@@ -167,10 +167,6 @@ whirlpool.o: whirlpool.c byte_order.h ustd.h whirlpool.h
 whirlpool_sbox.o: whirlpool_sbox.c byte_order.h ustd.h
 	$(CC) -c $(CFLAGS) $< -o $@
 
-# build shared library
-$(EXPORTS_FILE): $(SO_HEADERS)
-	sed -ne '1s/.*/{ global:/p; s/^RHASH_API.* \(rhash_[a-z0-9_]*\)(.*/  \1;/p; $$s/.*/local: *; };/p' $(SO_HEADERS) > $@
-
 $(LIBRHASH_SOLINK):
 	rm -f $(LIBRHASH_SOLINK)
 	ln -s $(LIBRHASH_SHARED) $(LIBRHASH_SOLINK)


### PR DESCRIPTION
The generated exports.sym contains rhash_wfile which is not defined on ELF platforms and causes an error for -Wl,--no-undefined-version. We could remove the pattern, but using a glob pattern `rhash_*` is simpler.