### PR TITLE
Fix #251: Retrieve symlink target size on Windows

### DIFF
--- a/tests/test_rhash.sh
+++ b/tests/test_rhash.sh
@@ -188,6 +188,16 @@ check "$TEST_RESULT" "$TEST_EXPECTED" .
 TEST_RESULT=$( $rhash --simple --gost --gost-cryptopro --gost-reverse test1K.data | $rhash -vc - 2>/dev/null | grep test1K.data )
 match "$TEST_RESULT" "^test1K.data *OK"
 
+new_test "test symlinked file size:   "
+MSYS=winsymlinks:nativestrict CYGWIN=winsymlinks:nativestrict ln -s test1K.data test1K-symlink.data >/dev/null 2>&1
+if [ -L "test1K-symlink.data" ]; then
+  TEST_RESULT=$( $rhash --printf "%f %d %s\n" test1K-symlink.data 2>/dev/null )
+  TEST_EXPECTED="test1K-symlink.data . 1024"
+  check "$TEST_RESULT" "$TEST_EXPECTED"
+else
+  printf "Skipped - unable to create the symlink\n"
+fi
+
 new_test "test handling empty files:  "
 EMPTY_FILE="$RHASH_TMP/test-empty.file"
 printf "" > "$EMPTY_FILE"


### PR DESCRIPTION
Disclaimer: I don't program in C, so please cut me some slack.

I'm not sure about the usage of `_fileno`, as I've seen a couple of comments in other parts of the source claiming that it was incompatible with `gcc -ansi`. However, it's already used in `hash_print.c`: https://github.com/rhash/RHash/blob/eb536fa8f40074b6881ca00e7fd775a7ae814a41/hash_print.c#L506-L510

The test case was a bit tricky because creating symlinks on Windows generally requires that the process is elevated, or that "Developer Mode" is enabled, which is why I chose to skip the test if the symlink was not created successfully.

I've tested these changes under MSYS2 (UCRT64) and Ubuntu 22.04 (WSL). The test case already passes on Ubuntu  if executed against master. Only the Windows implementation required changes to report the file sizes of symlink targets.