### PR TITLE
Upstream small patches from CMake

### DIFF
--- a/librhash/hex.c
+++ b/librhash/hex.c
@@ -110,6 +110,9 @@ size_t rhash_base64_url_encoded_helper(char* dst, const unsigned char* src, size
 {
 #define B64_CHUNK_SIZE 120
 	char buffer[164];
+	#ifdef __clang_analyzer__
+	memset(buffer, 0, sizeof(buffer));
+	#endif
 	RHASH_ASSERT((BASE64_LENGTH(B64_CHUNK_SIZE) + 4) <= sizeof(buffer));
 	RHASH_ASSERT((B64_CHUNK_SIZE % 6) == 0);
 	if (url_encode) {

--- a/librhash/rhash.c
+++ b/librhash/rhash.c
@@ -20,6 +20,7 @@
 #endif
 
 /* macros for large file support, must be defined before any include file */
+#define _LARGEFILE_SOURCE
 #define _LARGEFILE64_SOURCE
 #define _FILE_OFFSET_BITS 64
 

--- a/librhash/rhash.h
+++ b/librhash/rhash.h
@@ -392,7 +392,7 @@ RHASH_API size_t rhash_print_bytes(char* output,
  *               flags RHPR_UPPERCASE, RHPR_HEX, RHPR_BASE32, RHPR_BASE64, etc.
  * @return the number of written characters on success or 0 on fail
  */
-RHASH_API size_t rhash_print(char* output, rhash ctx, unsigned hash_id,
+RHASH_API size_t rhash_print(char* output, rhash context, unsigned hash_id,
 	int flags);
 
 /**

--- a/librhash/util.h
+++ b/librhash/util.h
@@ -42,7 +42,7 @@ extern "C" {
 # define rhash_aligned_free(ptr) _aligned_free(ptr)
 
 #elif !defined(NO_STDC_ALIGNED_ALLOC) && (__STDC_VERSION__ >= 201112L || defined(_ISOC11_SOURCE)) \
-	&& !defined(__APPLE__) && !defined(__HAIKU__) \
+	&& !defined(__APPLE__) && !defined(__HAIKU__) && !defined(__sun) \
 	&& (!defined(__ANDROID_API__) || __ANDROID_API__ >= 28)
 
 # define HAS_STDC_ALIGNED_ALLOC


### PR DESCRIPTION
CMake uses RHash and locally applied some smaller patches. I think they are better upstreamed to share the patches and keeping both codes as similar as possible.