### PR TITLE
Add GNU target platform support for configure argument

### DIFF
--- a/configure
+++ b/configure
@@ -533,6 +533,7 @@ else
       wine) TARGET_OS=Wine ;;
       darwin*) TARGET_OS=Darwin ;;
       cygwin*) TARGET_OS=CYGWIN ;;
+      gnu) TARGET_OS=GNU ;;
     esac
   }
   TARGET_OS="UNKNOWN"

--- a/configure
+++ b/configure
@@ -724,7 +724,7 @@ elif darwin; then
   SHARED_EXT=".${RHASH_VERSION}.dylib"
   SO_MAJ_EXT=".${RHASH_VERSION_MAJOR}.dylib"
   SOLINK_EXT=".dylib"
-elif linux || bsd; then
+elif linux || bsd || gnu; then
   # use the full library version for the library file extension
   SHARED_EXT=".so.${RHASH_VERSION}"
 fi


### PR DESCRIPTION
GNU is supported for auto-configuration but was not when defining the platform with --target. This is now supported.

And fix the name of the shared library to follow the same as linux and bsd