### PR TITLE
php bindings: PHP8 compatibility

### DIFF
--- a/bindings/php/php_compatibility.h
+++ b/bindings/php/php_compatibility.h
@@ -55,4 +55,9 @@ typedef size_t strsize_t;
 
 #endif
 
+#if PHP_MAJOR_VERSION >= 8
+#define TSRMLS_CC
+#define TSRMLS_DC
+#endif
+
 #endif /* PHP_PORTABLE_H */

--- a/bindings/php/php_rhash.c
+++ b/bindings/php/php_rhash.c
@@ -449,7 +449,7 @@ PHP_FUNCTION(rhash_file) {
 		RETURN_NULL();
 	}
 	if (!hash_id || !(context = rhash_init(hash_id))) {
-		RETURN_NULL()
+		RETURN_NULL();
 	}
 	res = _php_rhash_file(INTERNAL_FUNCTION_PARAM_PASSTHRU, context, path, -1, -1);
 	rhash_final(context, 0);
@@ -629,7 +629,7 @@ static void _php_get_hash(INTERNAL_FUNCTION_PARAMETERS, int print_flags)
 		RETURN_FALSE;
 	}
 	length = rhash_print(buffer, obj->rhash, hash_id, print_flags);
-	_RETURN_STRINGL(buffer, length)
+	_RETURN_STRINGL(buffer, length);
 }
 /* }}} */
 


### PR DESCRIPTION
Currently php bindings does not compile with PHP8, this PR fixes that.