### PR TITLE
Align install_name on OSX with Linux

### DIFF
--- a/configure
+++ b/configure
@@ -829,7 +829,7 @@ if win32; then
   LIBRHASH_EXPORTS_SKIP="__NO_SKIP__"
 elif darwin; then
   LIBRHASH_SH_CFLAGS="-fpic"
-  LIBRHASH_SH_LDFLAGS='-dynamiclib -Wl,-install_name,$(LIBDIR)/$@'
+  LIBRHASH_SH_LDFLAGS='-dynamiclib -Wl,-install_name,$(LIBRHASH_SO_MAJ)/$@'
 else
   LIBRHASH_SH_CFLAGS="-fpic"
   LIBRHASH_SH_LDFLAGS="-shared -Wl${SHARED_VSCRIPT},-soname,\$(LIBRHASH_SO_MAJ)"


### PR DESCRIPTION
Currently, the install_name on OSX is pinning to x.x.x whereas on Linux (or non-OSX), we link to librhash.so.X (i.e. only major). This brings both in line.