### PR TITLE
Feat: Add support for sw_64 architecture

### DIFF
--- a/configure
+++ b/configure
@@ -500,6 +500,7 @@ if test -z "$BUILD_TARGET"; then
           sh3|sh4|sh4a) HOST_ARCH=sh ;;
           s390) HOST_ARCH=s390 ;;
           s390x) HOST_ARCH=s390x ;;
+          sw_64) HOST_ARCH=sw_64 ;;
           *mips*) HOST_ARCH=mips ;;
           nios2) HOST_ARCH=nios2 ;;
           vax) HOST_ARCH=vax ;;

--- a/librhash/test_lib.h
+++ b/librhash/test_lib.h
@@ -123,6 +123,15 @@ char* compiler_flags = "Compile-time flags:"
 #ifdef sparc
 	" sparc"
 #endif
+#ifdef __sw_64
+	" __sw_64"
+#endif
+#ifdef __sw_64__
+	" __sw_64__"
+#endif
+#ifdef sw_64
+	" sw_64"
+#endif
 #ifdef _ARCH_PPC
 	" _ARCH_PPC"
 #endif


### PR DESCRIPTION
Updated the configure script and test_lib.h to recognize and handle the sw_64 architecture, ensuring proper detection and reporting of compile-time flags for this platform.

In this commit, support for a new architecture sw_64 is added to RHash. sw_64 is a new RISC ISA in open source world. Though it is a rather new ISA, it has been added to openEuler and openAnolis port since 2020.

More information about sw_64 ISA:
```bash
$ uname -m
sw_64
$ gcc -E -dM - < /dev/null|grep __sw_64__
#define __sw_64__ 1
$ gcc -E -dM - < /dev/null|grep BYTE_ORDER
#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
```